### PR TITLE
Fix thread join in stop_frame_capture

### DIFF
--- a/src/cam/camera.py
+++ b/src/cam/camera.py
@@ -310,8 +310,13 @@ class Camera:
         self.frame_thread.start()
 
     def stop_frame_capture(self) -> None:
+        """Stop the frame grabbing thread."""
         self.is_running = False
-        if self.frame_thread and self.frame_thread.is_alive():
+        if (
+            self.frame_thread
+            and self.frame_thread.is_alive()
+            and threading.current_thread() is not self.frame_thread
+        ):
             self.frame_thread.join(timeout=2)
 
     def _capture_loop(self) -> None:


### PR DESCRIPTION
## Summary
- avoid joining the frame thread when stop_frame_capture is called from inside the thread itself

## Testing
- `python -m py_compile src/cam/camera.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687445f77ddc83338986d16acf5bb62a