### PR TITLE
Fix AlertSystem initialization in GUI

### DIFF
--- a/src/gui/elements/emailcard.py
+++ b/src/gui/elements/emailcard.py
@@ -116,7 +116,7 @@ def create_emailcard():
                         ui.tooltip('Ausgewählte E-Mail-Adressen löschen')
 
                     def send_test_email():
-                        alert = AlertSystem(config.email, config.measurement)
+                        alert = AlertSystem(config.email, config.measurement, config)
                         if alert.send_test_email():
                             ui.notify("Test-E-Mail erfolgreich gesendet", color="positive")
                         else:

--- a/src/gui/elements/measurementcard.py
+++ b/src/gui/elements/measurementcard.py
@@ -8,7 +8,7 @@ from src.measurement import MeasurementController
 def create_measurement_card():
 
     config = load_config()
-    alert_system = AlertSystem(config.email, config.measurement)
+    alert_system = AlertSystem(config.email, config.measurement, config)
     measurement_controller = MeasurementController(config.measurement, alert_system)
 
     # ------------------------- Zustände -------------------------


### PR DESCRIPTION
## Summary
- pass `AppConfig` to `AlertSystem` when creating measurement and email cards

## Testing
- `pytest -q`
- `python - <<'PY'
from src.config import load_config
from src.alert import AlertSystem
cfg = load_config()
cfg.email.validate = lambda: ['ok']
AlertSystem(cfg.email, cfg.measurement, cfg)
print('init success')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68744658f3b48333b4e091bf871c6797