### PR TITLE
Fix alert inactivity calculations

### DIFF
--- a/src/measurement.py
+++ b/src/measurement.py
@@ -112,7 +112,7 @@ class MeasurementController:
             self.is_session_active = True
             
             # Alert-Status zurücksetzen
-            self.last_motion_time = None
+            self.last_motion_time = self.session_start_time
             self.alert_triggered = False
             self.alert_trigger_time = None
             
@@ -279,9 +279,13 @@ class MeasurementController:
             return False
         
         if self.last_motion_time is None:
+            reference_time = self.session_start_time
+        else:
+            reference_time = self.last_motion_time
+        if reference_time is None:
             return False
-        
-        time_since_motion = datetime.now() - self.last_motion_time
+
+        time_since_motion = datetime.now() - reference_time
         alert_delay = timedelta(seconds=self.config.alert_delay_seconds)
         
         return time_since_motion >= alert_delay

--- a/tests/test_measurement_controller.py
+++ b/tests/test_measurement_controller.py
@@ -1,0 +1,42 @@
+from datetime import datetime, timedelta
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.measurement import MeasurementController
+from src.config import MeasurementConfig
+
+
+def create_controller(alert_delay=60):
+    cfg = MeasurementConfig(
+        auto_start=False,
+        session_timeout_minutes=10,
+        save_alert_images=False,
+        image_save_path='.',
+        image_format='jpg',
+        image_quality=80,
+        alert_delay_seconds=alert_delay,
+    )
+    return MeasurementController(cfg)
+
+
+def test_last_motion_initialized_on_start():
+    mc = create_controller()
+    assert mc.last_motion_time is None
+    mc.start_session("s1")
+    assert mc.session_start_time is not None
+    assert mc.last_motion_time == mc.session_start_time
+
+
+def test_should_trigger_uses_session_start_when_no_motion():
+    mc = create_controller(alert_delay=1)
+    mc.start_session("s1")
+    # Simulate that no motion timestamp is recorded
+    mc.last_motion_time = None
+    mc.session_start_time = datetime.now() - timedelta(seconds=2)
+    assert mc.should_trigger_alert() is True
+
+    mc.last_motion_time = None
+    mc.session_start_time = datetime.now()
+    assert mc.should_trigger_alert() is False


### PR DESCRIPTION
## Summary
- initialize `last_motion_time` when starting a session
- allow `should_trigger_alert` to fall back to the session start time
- add regression tests for these behaviours

## Testing
- `pip install -r requirements.txt`
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_6874529fd97c8333820ebbba52473f03