### PR TITLE
Integrate measurement controller with GUI

### DIFF
--- a/src/gui/elements/measurementcard.py
+++ b/src/gui/elements/measurementcard.py
@@ -5,11 +5,12 @@ from src.alert import AlertSystem
 from src.config import load_config, save_config
 from src.measurement import MeasurementController
 
-def create_measurement_card():
+def create_measurement_card(measurement_controller: MeasurementController | None = None):
 
     config = load_config()
-    alert_system = AlertSystem(config.email, config.measurement, config)
-    measurement_controller = MeasurementController(config.measurement, alert_system)
+    if measurement_controller is None:
+        alert_system = AlertSystem(config.email, config.measurement, config)
+        measurement_controller = MeasurementController(config.measurement, alert_system)
 
     # ------------------------- Zustände -------------------------
 

--- a/src/gui/elements/motion_status_element.py
+++ b/src/gui/elements/motion_status_element.py
@@ -2,7 +2,9 @@ from nicegui import ui
 from fastapi import Request
 from datetime import datetime
 
-def create_motion_status_element(camera):
+from src.measurement import MeasurementController
+
+def create_motion_status_element(camera, measurement_controller: MeasurementController | None = None):
     
     # ---------- interne Statusvariablen ----------
     motion_detected: bool = False           # Start: keine Bewegung
@@ -39,6 +41,8 @@ def create_motion_status_element(camera):
             motion_detected = result.motion_detected
             last_changed = datetime.fromtimestamp(result.timestamp)
             refresh_view()
+        if measurement_controller is not None:
+            measurement_controller.on_motion_detected(result)
 
     camera.enable_motion_detection(_motion_callback)
     # ---------- REST-Endpunkt für Dein Analyse-Skript -------------------

--- a/tests/test_motion_status_integration.py
+++ b/tests/test_motion_status_integration.py
@@ -1,0 +1,22 @@
+from src.gui.elements.motion_status_element import create_motion_status_element
+from src.cam.motion import MotionResult
+
+class DummyCamera:
+    def enable_motion_detection(self, callback):
+        self.callback = callback
+
+class DummyMC:
+    def __init__(self):
+        self.called_with = []
+    def on_motion_detected(self, result):
+        self.called_with.append(result)
+
+
+def test_motion_event_forwards_to_measurement_controller():
+    camera = DummyCamera()
+    mc = DummyMC()
+    # this should register callback
+    create_motion_status_element(camera, mc)
+    dummy_result = MotionResult(True, 1.0, timestamp=123.0)
+    camera.callback(None, dummy_result)
+    assert mc.called_with == [dummy_result]


### PR DESCRIPTION
## Summary
- instantiate `MeasurementController` once in `gui.py`
- pass the controller to `motion_status_element` and `measurement_card`
- allow `measurement_card` and `motion_status_element` to use provided controller
- forward motion events to controller
- test that motion callbacks trigger controller calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874c5e242e48333b3d0a3d17d9b3fe8