### PR TITLE
Add configurable config path and use GUI settings

### DIFF
--- a/src/gui/gui.py
+++ b/src/gui/gui.py
@@ -28,12 +28,16 @@ global_measurement_controller: MeasurementController | None = None
 global_alert_system: AlertSystem | None = None
 
 
-def init_camera() -> Camera | None:
-    """Initialisiere Kamera und starte die Bilderfassung."""
+def init_camera(config_path: str = "config/config.yaml") -> Camera | None:
+    """Initialisiere Kamera und starte die Bilderfassung.
+
+    Args:
+        config_path: Pfad zur zu ladenden Konfiguration
+    """
 
     print("Initialisiere Kamera ...")
     try:
-        cam = Camera()
+        cam = Camera(config_path)
         cam.initialize_routes()
         cam.start_frame_capture()
         print("Kamera erfolgreich initialisiert")
@@ -43,25 +47,30 @@ def init_camera() -> Camera | None:
         return None
 
 
-def create_gui() -> None:
-    """Starte die GUI und initialisiere bei Bedarf die Kamera."""
+def create_gui(config_path: str = "config/config.yaml") -> None:
+    """Starte die GUI und initialisiere bei Bedarf die Kamera.
+
+    Args:
+        config_path: Pfad zur zu ladenden Konfigurationsdatei
+    """
 
     global global_camera, global_measurement_controller, global_alert_system
-    global_camera = init_camera()
+    global_camera = init_camera(config_path)
     if not global_camera:
         ui.notify("Kamera konnte nicht initialisiert werden.", type='negative')
         return 
     if global_alert_system is None:
         try:
-            global_alert_system = create_alert_system_from_config()
+            global_alert_system = create_alert_system_from_config(config_path)
         except Exception as exc:
             logger.error(f"AlertSystem-Init fehlgeschlagen: {exc}")
             global_alert_system = None
     if global_measurement_controller is None:
         try:
             global_measurement_controller = create_measurement_controller_from_config(
+                config_path=config_path,
                 alert_system=global_alert_system,
-                camera=global_camera
+                camera=global_camera,
             )
         except Exception as exc:
             logger.error(f"MeasurementController-Init fehlgeschlagen: {exc}")

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,23 @@
 import sys
 import logging
 from pathlib import Path
+import argparse
 from nicegui import ui
 
 # Projekt-Root zum Python-Pfad hinzufügen
 project_root = Path(__file__).parent
 sys.path.insert(0, str(project_root))
+
+
+def parse_args() -> argparse.Namespace:
+    """Kommandozeilenargumente parsen."""
+    parser = argparse.ArgumentParser(description="CVD-Tracker")
+    parser.add_argument(
+        "--config",
+        default="config/config.yaml",
+        help="Pfad zur Konfigurationsdatei",
+    )
+    return parser.parse_args()
 
 def setup_logging():
     """Konfiguriert das Logging-System"""
@@ -23,8 +35,9 @@ def setup_logging():
         ]
     )
 
-def main():
+def main() -> int:
     """Haupteinstiegspunkt der Anwendung"""
+    args = parse_args()
     try:
         # Logging zuerst konfigurieren
         setup_logging()
@@ -32,14 +45,17 @@ def main():
         
         logger.info("Starte CVD-Tracker Anwendung...")
         
+        from src.config import load_config
+        cfg = load_config(args.config)
+
         # GUI erstellen
         from gui.gui import create_gui
-        create_gui()
+        create_gui(config_path=args.config)
         
         # NiceGUI starten
         ui.run(
-            host='0.0.0.0', 
-            port=8080, 
+            host=cfg.gui.host,
+            port=cfg.gui.port,
             title='CVD-Tracker',
             favicon='https://www.tuhh.de/favicon.ico',
             reload=False


### PR DESCRIPTION
## Summary
- allow passing `--config` to choose a configuration file
- initialize GUI components with that path
- start NiceGUI server with host and port from config

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875102dc71883338951afe7113f0cb5