### PR TITLE
Integrate config-based logging

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -3,44 +3,30 @@ import logging
 from pathlib import Path
 from nicegui import ui
 
+from src.config import load_config
+
 # Projekt-Root zum Python-Pfad hinzufügen
 project_root = Path(__file__).parent
 sys.path.insert(0, str(project_root))
 
-def setup_logging():
-    """Konfiguriert das Logging-System"""
-    # Logs-Verzeichnis erstellen falls nicht vorhanden
-    logs_dir = Path('logs')
-    logs_dir.mkdir(exist_ok=True)
-    
-    logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S',
-        handlers=[
-            logging.StreamHandler(),
-            logging.FileHandler(logs_dir / 'app.log', encoding='utf-8')
-        ]
-    )
-
 def main():
     """Haupteinstiegspunkt der Anwendung"""
     try:
-        # Logging zuerst konfigurieren
-        setup_logging()
-        logger = logging.getLogger(__name__)
-        
+        # Konfiguration laden und Logger einrichten
+        cfg = load_config()
+        logger = cfg.logging.setup_logger("cvd_tracker.main")
+
         logger.info("Starte CVD-Tracker Anwendung...")
-        
+
         # GUI erstellen
         from gui.gui import create_gui
         create_gui()
         
         # NiceGUI starten
         ui.run(
-            host='0.0.0.0', 
-            port=8080, 
-            title='CVD-Tracker',
+            host=cfg.gui.host,
+            port=cfg.gui.port,
+            title=cfg.gui.title,
             favicon='https://www.tuhh.de/favicon.ico',
             reload=False
         )
@@ -53,7 +39,7 @@ def main():
         return 1
         
     except Exception as e:
-        logger = logging.getLogger(__name__)
+        logger = logging.getLogger("cvd_tracker.main")
         logger.error(f"Fehler beim Start: {e}", exc_info=True)
         return 1
     


### PR DESCRIPTION
## Summary
- initialize configuration on startup
- use `LoggingConfig.setup_logger` for main logger
- run webserver with settings from config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6875100fc1348333b0769c41ff86580d