### PR TITLE
Fix config loading path in main

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ def main() -> int:
     args = parse_args()
     try:
         # Konfiguration laden und Logger einrichten
-        cfg = load_config()
+        cfg = load_config(args.config)
         logger = cfg.logging.setup_logger("cvd_tracker.main")
 
         logger.info("Starting CVD-Tracker application...")


### PR DESCRIPTION
## Summary
- pass config path from CLI to `load_config`
- update tests to ensure environment setup and run

## Testing
- `pip install -r requirements.txt`
- `pip install requests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d443559548333a38cdf0263e784dc