### PR TITLE
Fix send_test_email docstring

### DIFF
--- a/src/alert.py
+++ b/src/alert.py
@@ -492,16 +492,14 @@ class AlertSystem:
     def send_test_email(self) -> bool:
         """
         Sendet Test-E-Mail an alle konfigurierten Empfänger.
-        
-        Args:
-            test_message: Test-Nachricht
-            
+
         Returns:
             True wenn mindestens eine E-Mail erfolgreich gesendet
         """
         try:
             timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             subject = f"Test email - {timestamp}"
+            # Beispielinhalt der Test-E-Mail erzeugen
             test_message =(
                     f"Motion has not been detected since {timestamp}!\n"
                     f"Please check the website at: {self.email_config.website_url}\n\n"


### PR DESCRIPTION
## Summary
- update docstring for `send_test_email` so it matches function signature
- clarify comment when building the test message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d445311e88333b76319d672251653