### PR TITLE
Remove unused turtle import from camera

### DIFF
--- a/src/cam/camera.py
+++ b/src/cam/camera.py
@@ -6,7 +6,6 @@ import signal
 import threading
 import time
 from dataclasses import asdict
-from turtle import width
 from typing import Callable, Optional
 import os
 


### PR DESCRIPTION
## Summary
- delete unused `width` import from `camera.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d445390748333a64bf47f7ff3715f