### PR TITLE
Fix lambda formatting

### DIFF
--- a/src/gui/elements/measurementcard.py
+++ b/src/gui/elements/measurementcard.py
@@ -235,10 +235,8 @@ def create_measurement_card(measurement_controller: MeasurementController | None
     enable_limit.on('update:model-value', toggle_duration)
     enable_limit.on('update:model-value', lambda e: persist_settings())
      
-    duration_input.on('blur', lambda e:
-    persist_settings() if enable_limit.value else None)
-    duration_input.on('keydown.enter', lambda e:
-    persist_settings() if enable_limit.value else None)
+    duration_input.on('blur', lambda e: persist_settings() if enable_limit.value else None)
+    duration_input.on('keydown.enter', lambda e: persist_settings() if enable_limit.value else None)
     ui.timer(1.0, tick)
 
     persist_settings()


### PR DESCRIPTION
## Summary
- keep lambda functions on single lines in measurementcard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d44cd72988333b1bdaec3e9b26768