### PR TITLE
Fix alert delay rounding in measurement

### DIFF
--- a/src/measurement.py
+++ b/src/measurement.py
@@ -102,11 +102,12 @@ class MeasurementController:
     
     # === Session-Management ===
     def _ensure_valid_time(self) -> None:
-        min_minutes = max(5, math.ceil(self.config.alert_delay_seconds // 60))
+        alert_delay_minutes = math.ceil(self.config.alert_delay_seconds / 60)
+        min_minutes = max(5, alert_delay_minutes)
         if 0 < self.config.session_timeout_minutes < min_minutes:
             self.logger.warning(
                 f"Session timeout ({self.config.session_timeout_minutes}min) "
-                f"is shorter than alert delay 5 minutes - "
+                f"is shorter than alert delay {alert_delay_minutes} minutes - "
                 f"setting to {min_minutes}min"
             )
             self.config.session_timeout_minutes = min_minutes


### PR DESCRIPTION
## Summary
- ensure fractional alert delay minutes round up
- include computed alert delay in warning message

## Testing
- `pip install -r requirements.txt`
- `pip install requests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d45d670508333b7b0955e0279754d