### PR TITLE
refactor gui config passing

### DIFF
--- a/src/gui/elements/emailcard.py
+++ b/src/gui/elements/emailcard.py
@@ -1,11 +1,10 @@
 from typing import Dict
 import re
 from nicegui import ui
-from src.config import save_config, load_config
+from src.config import AppConfig, save_config
 from src.alert import AlertSystem
 
-def create_emailcard():
-    config = load_config()
+def create_emailcard(*, config: AppConfig) -> None:
     state: Dict = {
         "recipients": list(config.email.recipients),
         "smtp": {

--- a/src/gui/elements/measurementcard.py
+++ b/src/gui/elements/measurementcard.py
@@ -2,13 +2,16 @@ from datetime import datetime, timedelta
 from nicegui import ui, background_tasks
 
 from src.alert import AlertSystem
-from src.config import load_config, save_config
+from src.config import AppConfig, save_config
 from src.measurement import MeasurementController
 from src.cam.camera import Camera
 
-def create_measurement_card(measurement_controller: MeasurementController | None = None, camera: Camera | None = None):
-    
-    config = load_config()
+def create_measurement_card(
+    measurement_controller: MeasurementController | None = None,
+    camera: Camera | None = None,
+    *,
+    config: AppConfig,
+) -> None:
     if measurement_controller is None:
         alert_system = AlertSystem(config.email, config.measurement, config)
         measurement_controller = MeasurementController(config.measurement, alert_system)

--- a/src/gui/gui_.py
+++ b/src/gui/gui_.py
@@ -12,7 +12,7 @@ from src.gui.elements import (
 
 from src.measurement import create_measurement_controller_from_config, MeasurementController
 from src.alert import create_alert_system_from_config, AlertSystem
-from src.config import logger
+from src.config import logger, load_config
 
 from src.cam.camera import Camera
 
@@ -51,6 +51,7 @@ def create_gui(config_path: str = "config/config.yaml") -> None:
     """
 
     global global_camera, global_measurement_controller, global_alert_system
+    config = load_config(config_path)
     global_camera = init_camera(config_path)
     if not global_camera:
         ui.notify("Camera could not be initialized.", type='negative')
@@ -107,11 +108,11 @@ def create_gui(config_path: str = "config/config.yaml") -> None:
                 with ui.column().classes("h-full"):
                     create_motion_status_element(global_camera, global_measurement_controller)
                 with ui.column().classes("h-full"):
-                    create_measurement_card(global_measurement_controller)
+                    create_measurement_card(global_measurement_controller, config=config)
 
         with ui.column().classes("gap-4"):
             create_uvc_content(camera=global_camera)
             create_motiondetection_card(camera=global_camera)
-            create_emailcard()
+            create_emailcard(config=config)
     
     


### PR DESCRIPTION
## Summary
- load NiceGUI config once in `create_gui`
- pass config to `create_emailcard` and `create_measurement_card`
- update measurement and email cards to accept config instance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d4920562c8333916de33df4a1dce4