### PR TITLE
Adjust ROI cropping and add regression test

### DIFF
--- a/src/cam/motion.py
+++ b/src/cam/motion.py
@@ -159,19 +159,20 @@ class MotionDetector:
             else:
                 gray_frame = frame.copy()
             
-            # Gausssche Unschärfe für Rauschreduzierung
-            blurred = cv2.GaussianBlur(gray_frame, (5, 5), 0)
-            
-            # ROI anwenden falls aktiviert
+            # ROI direkt nach Graustufen anwenden
             roi_used = False
+            roi_frame = gray_frame
             if hasattr(self.roi, 'enabled') and self.roi.enabled:
-                h, w = blurred.shape[:2]
+                h, w = gray_frame.shape[:2]
                 x = max(0, min(self.roi.x, w - 1))
                 y = max(0, min(self.roi.y, h - 1))
                 x2 = max(x + 1, min(self.roi.x + self.roi.width, w))
                 y2 = max(y + 1, min(self.roi.y + self.roi.height, h))
-                blurred = blurred[y:y2, x:x2]
+                roi_frame = gray_frame[y:y2, x:x2]
                 roi_used = True
+
+            # Gausssche Unschärfe für Rauschreduzierung
+            blurred = cv2.GaussianBlur(roi_frame, (5, 5), 0)
             
             # Learning-Phase verwalten
             if self.is_learning:

--- a/tests/test_motion_detector.py
+++ b/tests/test_motion_detector.py
@@ -1,0 +1,29 @@
+import numpy as np
+from src.cam.motion import MotionDetector, MotionResult
+from src.config import MotionDetectionConfig
+
+def create_detector(roi_enabled=False):
+    cfg = MotionDetectionConfig(
+        region_of_interest={
+            'enabled': roi_enabled,
+            'x': 0,
+            'y': 0,
+            'width': 0,
+            'height': 0,
+        },
+        sensitivity=0.5,
+        background_learning_rate=0.1,
+        min_contour_area=5,
+    )
+    return MotionDetector(cfg)
+
+def test_detect_motion_no_roi():
+    detector = create_detector(roi_enabled=False)
+    frame = np.zeros((100, 100), dtype=np.uint8)
+    result1 = detector.detect_motion(frame)
+    result2 = detector.detect_motion(frame)
+    assert isinstance(result1, MotionResult)
+    assert isinstance(result2, MotionResult)
+    assert result1.roi_used is False
+    assert result2.roi_used is False
+


### PR DESCRIPTION
## Summary
- apply ROI crop before blur and background subtraction in `MotionDetector.detect_motion`
- test `MotionDetector` without ROI enabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d4946fe388333b26c26e53f05d48b