### PR TITLE
Avoid duplicate logging handlers

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -16,6 +16,8 @@ logging.basicConfig(
 )
 
 logger = logging.getLogger(__name__)
+# Track whether the application logger was already initialized
+_initialized_logger = False
 from enum import Enum
 
 # ---------------------------------------------------------------------------
@@ -270,7 +272,12 @@ class LoggingConfig:
     
     def setup_logger(self, name: str = "cvd_tracker") -> logging.Logger:
         """RotatingFileHandler-Logger einrichten"""
+        global _initialized_logger
         logger = logging.getLogger(name)
+        if _initialized_logger:
+            # avoid adding handlers multiple times
+            return logger
+
         logger.setLevel(getattr(logging, self.level.upper()))
         
         # Vorherige Handler entfernen
@@ -305,7 +312,10 @@ class LoggingConfig:
             handler.setFormatter(formatter)
             logger.addHandler(handler)
 
-        logger.info(f"🚀 Logging initialized: {self.file} (max: {self.max_file_size_mb}MB, backups: {self.backup_count})")
+        logger.info(
+            f"🚀 Logging initialized: {self.file} (max: {self.max_file_size_mb}MB, backups: {self.backup_count})"
+        )
+        _initialized_logger = True
         return logger
 
 # ---------------------------------------------------------------------------

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,14 @@
+import logging
+from src import config as config_module
+from src.config import LoggingConfig
+
+
+def test_setup_logger_runs_once(tmp_path, monkeypatch):
+    monkeypatch.setattr(config_module, '_initialized_logger', False)
+    log_file = tmp_path / "app.log"
+    cfg = LoggingConfig(level="INFO", file=str(log_file))
+    logger = cfg.setup_logger("test_logger")
+    first_count = len(logger.handlers)
+    cfg.setup_logger("test_logger")
+    second_count = len(logger.handlers)
+    assert second_count == first_count


### PR DESCRIPTION
## Summary
- prevent calling `setup_logger` multiple times
- ensure handlers are not duplicated by tracking initialization state
- test logging configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d53b665cc83339f24fa1ecabec833