### PR TITLE
Fix MIME image handling

### DIFF
--- a/src/alert.py
+++ b/src/alert.py
@@ -173,10 +173,12 @@ class AlertSystem:
                 timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
                 img_buffer = None
                 filename: str | None = None
+                image_bytes: bytes | None = None
 
                 if camera_frame is not None:
                     ok, img_buffer, filename = self._encode_frame(camera_frame, ts=timestamp)
                     assert img_buffer is not None and filename is not None
+                    image_bytes = img_buffer.tobytes()
                     if ok and self.measurement_config.save_alert_images:
                         self._save_alert_image(img_buffer, filename)
 
@@ -184,8 +186,8 @@ class AlertSystem:
                             msg = self._create_email_message(subject, body, recipient)
                             
                             # Bild-Anhang hinzufügen wenn verfügbar
-                            if ok and img_buffer is not None and filename is not None:
-                                img_attach = MIMEImage(img_buffer.tobytes())
+                            if ok and image_bytes is not None and filename is not None:
+                                img_attach = MIMEImage(image_bytes)
                                 img_attach.add_header('Content-Disposition', f'attachment; filename="{filename}"')
                                 msg.attach(img_attach)
 

--- a/tests/test_alert_system.py
+++ b/tests/test_alert_system.py
@@ -1,0 +1,38 @@
+import numpy as np
+from datetime import datetime
+
+from src.alert import AlertSystem
+from src.config import _create_default_config
+
+
+def test_send_motion_alert_includes_image(monkeypatch):
+    cfg = _create_default_config()
+    cfg.measurement.save_alert_images = True
+    # Ensure recipients list not empty and minimal valid email settings
+    cfg.email.recipients = ["recipient@example.com"]
+    cfg.email.sender_email = "sender@example.com"
+    cfg.email.smtp_server = "localhost"
+    cfg.email.smtp_port = 25
+
+    alert = AlertSystem(cfg.email, cfg.measurement, cfg)
+
+    sent_messages = []
+
+    def fake_send_emails_batch(self, messages, max_retries=3):
+        sent_messages.extend(messages)
+        return len(messages)
+
+    monkeypatch.setattr(AlertSystem, "_send_emails_batch", fake_send_emails_batch)
+    monkeypatch.setattr(AlertSystem, "_save_alert_image", lambda self, buf, name: None)
+    monkeypatch.setattr(AlertSystem, "_should_send_alert_unsafe", lambda self: True)
+
+    frame = np.zeros((10, 10, 3), dtype=np.uint8)
+
+    assert alert.send_motion_alert(datetime.now(), "session", frame)
+    # One message per recipient
+    assert len(sent_messages) == len(cfg.email.recipients)
+
+    for _, msg in sent_messages:
+        images = [p for p in msg.walk() if p.get_content_maintype() == "image"]
+        assert len(images) == 1
+


### PR DESCRIPTION
## Summary
- store encoded frame bytes once in `send_motion_alert`
- reuse the prepared bytes for every `MIMEImage` instance
- test that alerts still include images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d53c3054c8333855b0ddf24273622