### PR TITLE
Fix config argument passthrough

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ def main() -> int:
     args = parse_args()
     try:
         # Konfiguration laden und Logger einrichten
-        cfg = load_config()
+        cfg = load_config(args.config)
         logger = cfg.logging.setup_logger("cvd_tracker.main")
 
         logger.info("Starting CVD-Tracker application...")


### PR DESCRIPTION
## Summary
- allow custom config path in main entrypoint

## Testing
- `pytest -q`
- `python main.py --config config/config.yaml` (fails later due to camera but starts the app)
- `python main.py --config /tmp/custom_config.yaml` (fails later due to camera but starts the app)

------
https://chatgpt.com/codex/tasks/task_e_687d53db9dfc8333ad761d451e1849eb