### PR TITLE
Fix cleanup for jpeg images

### DIFF
--- a/src/alert.py
+++ b/src/alert.py
@@ -420,7 +420,11 @@ class AlertSystem:
             save_path: Path to the image save location
         """
         try:
-            image_files = list(save_path.glob("alert_*.jpg")) + list(save_path.glob("alert_*.png"))
+            image_files = (
+                list(save_path.glob("alert_*.jpg")) +
+                list(save_path.glob("alert_*.jpeg")) +
+                list(save_path.glob("alert_*.png"))
+            )
             if len(image_files) > max_files:
                 # Sort by modification time, delete oldest
                 image_files.sort(key=lambda x: x.stat().st_mtime)

--- a/tests/test_cleanup_images.py
+++ b/tests/test_cleanup_images.py
@@ -1,0 +1,25 @@
+import logging
+import time
+from pathlib import Path
+from src.alert import AlertSystem
+
+class Dummy:
+    def __init__(self):
+        self.logger = logging.getLogger("dummy")
+
+
+def test_cleanup_removes_old_jpeg(tmp_path):
+    # create three files with slight time gaps
+    (tmp_path / "alert_old.jpeg").write_text("old")
+    time.sleep(0.01)
+    (tmp_path / "alert_new.jpg").write_text("new")
+    time.sleep(0.01)
+    (tmp_path / "alert_latest.png").write_text("latest")
+
+    dummy = Dummy()
+    AlertSystem._cleanup_image(dummy, tmp_path, max_files=2)
+
+    remaining = {p.name for p in tmp_path.iterdir()}
+    assert "alert_old.jpeg" not in remaining
+    assert "alert_new.jpg" in remaining
+    assert "alert_latest.png" in remaining


### PR DESCRIPTION
## Summary
- remove old *.jpeg files in AlertSystem's cleanup helper
- add regression test for jpeg cleanup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d54815ff483338c92a761be6279f8